### PR TITLE
Escape @ to avoid mailto links

### DIFF
--- a/docs/source/terminology.rst
+++ b/docs/source/terminology.rst
@@ -52,7 +52,7 @@ Other biologically-relevant chimeric transcript fusions may be driven by RNA pro
 
 Regulatory Fusions
 ##################
-Regulatory fusions are characterized by the rearrangement of regulatory elements from one gene near a second gene, typically resulting in the increased gene product expression of the second gene. This class of gene fusions should be described using the :ref:`regulatory-nomenclature`, and includes promoter-swapping gene fusions such as reg_p@TMPRSS2::ERG, as well as enhancer-driven gene fusions such as reg_e@GATA2::EVI1.
+Regulatory fusions are characterized by the rearrangement of regulatory elements from one gene near a second gene, typically resulting in the increased gene product expression of the second gene. This class of gene fusions should be described using the :ref:`regulatory-nomenclature`, and includes promoter-swapping gene fusions such as reg_p\@TMPRSS2::ERG, as well as enhancer-driven gene fusions such as reg_e\@GATA2::EVI1.
 
 :opt:`A regulatory fusion is the novel interaction of a regulatory element brought into proximity of a partner gene by a` :ref:`genomic rearrangement<rearrangements>`\ :opt:`, modulating gene product expression of the partner gene.`
 


### PR DESCRIPTION
Due to the `@` symbol, the regulatory fusion names were getting autoconverted to `mailto:` links which looked strange (and are non-functional). Escaping the `@` fixes the issue.


![Screenshot 2024-03-21 at 1 50 09 PM](https://github.com/cancervariants/fusions/assets/13370/cb75c85c-3835-4b51-a2b0-baaf8b5e5580)
