### PR TITLE
docs: redefine RF preservation as general attribute

### DIFF
--- a/docs/source/information_model.rst
+++ b/docs/source/information_model.rst
@@ -76,6 +76,28 @@ coordinate. Reference sequences used to describe Sequence Locations should be ve
      - 1..1
      - A coordinate representing the end of a genomic location.
 
+.. _reading-frame:
+
+Reading Frame
+#############
+A common attribute of a gene fusion is whether the reading frame is preserved in the expressed gene
+product (for categorical fusions) or whether it is predicted to be preserved based on assayed
+findings (for assayed fusions). This is typical of protein-coding gene fusions.
+
+.. list-table::
+   :class: clean-wrap
+   :header-rows: 1
+   :align: left
+   :widths: auto
+
+   * - Field
+     - Limits
+     - Description
+   * - Reading frame preserved
+     - 0..1
+     - Boolean indicating whether the reading frame must be preserved, or is predicted to be preserved.
+
+
 .. _structural-elements:
 
 Structural Elements
@@ -296,24 +318,6 @@ gene fusion.
    * - Associated gene
      - 1..1
      - The :ref:`gene-element` associated with the domain.
-
-Reading Frame
-#############
-A common attribute of a categorical gene fusion is whether the reading frame is preserved in the expressed gene
-product. This is typical of protein-coding gene fusions.
-
-.. list-table::
-   :class: clean-wrap
-   :header-rows: 1
-   :align: left
-   :widths: auto
-
-   * - Field
-     - Limits
-     - Description
-   * - Reading frame preserved
-     - 0..1
-     - Boolean indicating whether the reading frame must be preserved or not.
 
 Assayed Elements
 @@@@@@@@@@@@@@@@

--- a/docs/source/information_model.rst
+++ b/docs/source/information_model.rst
@@ -80,8 +80,8 @@ coordinate. Reference sequences used to describe Sequence Locations should be ve
 
 Reading Frame
 #############
-A common attribute of a gene fusion is whether the reading frame is preserved in the expressed gene
-product (for categorical fusions) or whether it is predicted to be preserved based on assayed
+A common attribute of a gene fusion is whether the reading frame is preserved in the transcript
+(for categorical fusions) or whether it is predicted to be preserved based on assayed
 findings (for assayed fusions). This is typical of protein-coding gene fusions.
 
 .. list-table::
@@ -95,7 +95,7 @@ findings (for assayed fusions). This is typical of protein-coding gene fusions.
      - Description
    * - Reading frame preserved
      - 0..1
-     - Boolean indicating whether the reading frame must be preserved, or is predicted to be preserved.
+     - Boolean indicating whether the reading frame is preserved.
 
 
 .. _structural-elements:


### PR DESCRIPTION
Following https://github.com/cancervariants/fusor/issues/152 -- making this PR per the adage that the best way to get clarity is to propose an incorrect answer. My rough sense is that there is a subtle difference in meaning for whether the reading frame must be preserved for the category of gene fusions, or if it is predicted to be preserved based on the results of an assay. However, I'm not sure if that should be represented as two different kinds of properties for each fusion type, or if it can be included under a common attribute.

Either way, if a change needs to be made, the structural elements SVG figure should also be regenerated.